### PR TITLE
Prepend comment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Optionally, you can set the application name shown in the log like so in an init
 For Rails 3 applications, the name will default to your Rails application name.
 For Rails 2 applications, "rails" is used as the default application name.
 
+#### Components
+
 You can also configure the components of the comment that will be appended,
 by setting `Marginalia::Comment.components`. By default, this is set to:
 
@@ -99,6 +101,16 @@ With ActiveRecord >= 3.2.19:
   * `:database` to include the configured database name.
 
 Pull requests for other included comment components are welcome.
+
+#### Prepend comments
+
+By default marginalia appends the comments at the end of the query. Certain databases, such as MySQL will truncate
+the query text. This is the case for slow query logs and the results of querying some InnoDB internal tables where the
+length of the query is more than 1024 bytes.
+
+In order to not lose the marginalia comments from your logs, you can prepend the comments using this option:
+
+    Marginalia::Comment.prepend_comment = true
 
 ## Contributing
 

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -48,7 +48,11 @@ module Marginalia
       Marginalia::Comment.update_adapter!(self)
       comment = Marginalia::Comment.construct_comment
       if comment.present? && !sql.include?(comment)
-        "#{sql} /*#{comment}*/"
+        if Marginalia::Comment.prepend_comment
+          "/*#{comment}*/ #{sql}"
+        else
+          "#{sql} /*#{comment}*/"
+        end
       else
         sql
       end

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -2,7 +2,7 @@ require 'socket'
 
 module Marginalia
   module Comment
-    mattr_accessor :components, :lines_to_ignore
+    mattr_accessor :components, :lines_to_ignore, :prepend_comment
     Marginalia::Comment.components ||= [:application, :controller, :action]
 
     def self.update!(controller = nil)

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -284,6 +284,15 @@ class MarginaliaTest < MiniTest::Test
     assert_equal Marginalia::Comment.escape_sql_comment('**//; DROP TABLE USERS;/*'), '; DROP TABLE USERS;'
   end
 
+  def test_add_comments_to_beginning_of_query
+    Marginalia::Comment.prepend_comment = true
+
+    ActiveRecord::Base.connection.execute "select id from posts"
+    assert_match %r{/\*application:rails\*/ select id from posts$}, @queries.first
+  ensure
+    Marginalia::Comment.prepend_comment = nil
+  end
+
   def teardown
     Marginalia.application_name = nil
     Marginalia::Comment.lines_to_ignore = nil


### PR DESCRIPTION
Adds an option to prepend comments to the beginning of the query